### PR TITLE
Use JsDelivr CDN for mod db

### DIFF
--- a/Scarab/Services/ModDatabase.cs
+++ b/Scarab/Services/ModDatabase.cs
@@ -12,8 +12,8 @@ namespace Scarab.Services
 {
     public class ModDatabase : IModDatabase
     {
-        private const string MODLINKS_URI = "https://raw.githubusercontent.com/hk-modding/modlinks/main/ModLinks.xml";
-        private const string APILINKS_URI = "https://raw.githubusercontent.com/hk-modding/modlinks/main/ApiLinks.xml";
+        private const string MODLINKS_URI = "https://cdn.jsdelivr.net/gh/hk-modding/modlinks@main/ModLinks.xml";
+        private const string APILINKS_URI = "https://cdn.jsdelivr.net/gh/hk-modding/modlinks@main/ApiLinks.xml";
 
         public (string Url, int Version) Api { get; }
 


### PR DESCRIPTION
JsDelivr is a free CDN which can be utilized for mod db fetching, if latency of file update is bearable.