### PR TITLE
Fix OS detection

### DIFF
--- a/Scarab/Models/ModLinks.cs
+++ b/Scarab/Models/ModLinks.cs
@@ -92,23 +92,35 @@ namespace Scarab.Models
                 + "}";
         }
 
-        public string SHA256 => Environment.OSVersion.Platform switch
+        public string SHA256 
         {
-            PlatformID.Win32NT => Windows.SHA256,
-            PlatformID.MacOSX => Mac.SHA256,
-            PlatformID.Unix => Linux.SHA256,
-            
-            var val => throw new NotSupportedException(val.ToString())
-        };
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                    return Windows.SHA256;
+                if (OperatingSystem.IsMacOS())
+                    return Mac.SHA256;
+                if (OperatingSystem.IsLinux())
+                    return Linux.SHA256;
 
-        public string OSUrl => Environment.OSVersion.Platform switch
+                throw new NotSupportedException(Environment.OSVersion.Platform.ToString());
+            }
+        }
+
+        public string OSUrl
         {
-            PlatformID.Win32NT => Windows.URL,
-            PlatformID.MacOSX => Mac.URL,
-            PlatformID.Unix => Linux.URL,
-
-            var val => throw new NotSupportedException(val.ToString())
-        };
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                    return Windows.URL;
+                if (OperatingSystem.IsMacOS())
+                    return Mac.URL;
+                if (OperatingSystem.IsLinux())
+                    return Linux.URL;
+                
+                throw new NotSupportedException(Environment.OSVersion.Platform.ToString());
+            }
+        }
     }
 
     public class Link


### PR DESCRIPTION
I had problems with the controller detection on macOS similar to #46 (but with a Switch Pro Controller). The root cause is the OS detection which uses legacy APIs that can't distinguish between Unix and macOS. On macOS 
`Environment.OSVersion.Platform == PlatformID.MacOSX` always evaluates to `false` whereas `Environment.OSVersion.Platform == PlatformID.Unix` always evaluates to `true`. This in turn leads to the download of the Linux modding API on macOS.

This PR fixes the OS detection by using the newer `OperatingSystem` APIs introduced in .NET 5.0; see e.g. https://docs.microsoft.com/en-us/dotnet/api/system.operatingsystem.ismacos?view=net-6.0.

I can't test the other cases myself unfortunately, because I only have macOS, but it should be straightforward to verify on the other operating systems.