### PR TITLE
i18n: Add pt-BR language & configuring remaining strings for internationalization

### DIFF
--- a/Scarab/Resources.pt-BR.resx
+++ b/Scarab/Resources.pt-BR.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MI_InstallText_Installed" xml:space="preserve">
-    <value>卸载</value>
+    <value>Desinstalar</value>
   </data>
   <data name="MI_InstallText_NotInstalled" xml:space="preserve">
-    <value>安装</value>
+    <value>Instalar</value>
   </data>
   <data name="MLVM_ApiButtonText_DisableAPI" xml:space="preserve">
-    <value>禁用API</value>
+    <value>Desativar API</value>
   </data>
   <data name="MLVM_ApiButtonText_EnableAPI" xml:space="preserve">
-    <value>启用API</value>
+    <value>Ativar API</value>
   </data>
   <data name="MLVM_ApiButtonText_ToggleAPI" xml:space="preserve">
-    <value>切换API</value>
+    <value>Ativar/Desativar API</value>
   </data>
   <data name="MLVM_ChangePathAsync_Msgbox_Text" xml:space="preserve">
-    <value>请重新启动Scarab以应用更改</value>
+    <value>Reabra o Scarab para aplicar seu novo caminho.</value>
   </data>
   <data name="MLVM_ChangePathAsync_Msgbox_Title" xml:space="preserve">
-    <value>游戏路径已更改</value>
+    <value>Caminho Alterado!</value>
   </data>
   <data name="MLVM_DisplayHashMismatch_Msgbox_Text" xml:space="preserve">
-    <value>{0}({1}) 的哈希值与给定的哈希值{2}不匹配，它已损坏。</value>
+    <value>O hash da transferência de {0} ({1}) não correspondeu com a assinatura concedida ({2}). Ele está corrompido ou o registro está incorreto.</value>
   </data>
   <data name="MLVM_DisplayHashMismatch_Msgbox_Title" xml:space="preserve">
-    <value>哈希值不匹配</value>
+    <value>Discrepância de hash!</value>
   </data>
   <data name="MLVM_DisplayNetworkError_Msgbox_Text" xml:space="preserve">
-    <value>无法下载{0}！资源可能已删除，或者未连接网络</value>
+    <value>Impossível baixar {0}! O site pode estar fora do ar ou você não possui conexão de rede.</value>
   </data>
   <data name="MLVM_DisplayNetworkError_Msgbox_Title" xml:space="preserve">
-    <value>网络错误</value>
+    <value>Erro de Rede</value>
   </data>
   <data name="MLVM_InternalUpdateInstallAsync_Msgbox_W_Text" xml:space="preserve">
-    <value>游戏正在运行，这可能会导致一些问题。是否关闭游戏？</value>
+    <value>Hollow Knight está aberto! Isto pode acarretar em problemas ao instalar mods. Deseja fechar o Hollow Knight?</value>
   </data>
   <data name="MLVM_InternalUpdateInstallAsync_Msgbox_W_Title" xml:space="preserve">
-    <value>警告</value>
+    <value>Aviso!</value>
   </data>
   <data name="MWVM_Impl_Error_Fetch_ModLinks_Error" xml:space="preserve">
-    <value>HTTP错误{0}</value>
+    <value>falhou com erro HTTP {0}</value>
   </data>
   <data name="MWVM_Impl_Error_Fetch_ModLinks_Msgbox_Text" xml:space="preserve">
-    <value>无法获取ModLinks，原因：{0}</value>
+    <value>Impossível obter o modlinks, a operação {0}</value>
   </data>
   <data name="MWVM_Impl_Error_Fetch_ModLinks_Msgbox_Title" xml:space="preserve">
-    <value>错误</value>
+    <value>Erro!</value>
   </data>
   <data name="MWVM_Impl_Error_Fetch_ModLinks_Timeout" xml:space="preserve">
-    <value>超时</value>
+    <value>excedeu o tempo limite</value>
   </data>
   <data name="MWVM_OutOfDate_GetLatest" xml:space="preserve">
-    <value>Get the latest release</value>
+    <value>Obter a última versão</value>
   </data>
   <data name="MWVM_OutOfDate_ContinueAnyways" xml:space="preserve">
-    <value>Continue anyways.</value>
+    <value>Continuar mesmo assim.</value>
   </data>
   <data name="MWVM_OutOfDate_Title" xml:space="preserve">
-    <value>Out of date!</value>
+    <value>Desatualizado!</value>
   </data>
   <data name="MWVM_OutOfDate_Message" xml:space="preserve">
-    <value>This program is out of date! It may not function correctly.</value>
+    <value>Este programa está desatualizado! Ele pode não funcionar corretamente.</value>
   </data>
   <data name="MWVM_Warning" xml:space="preserve">
-    <value>Warning</value>
+    <value>Aviso</value>
   </data>
   <data name="MWVM_InvalidSavedPath_Message" xml:space="preserve">
-    <value>The saved Hollow Knight path is invalid, please re-select a valid path.</value>
+    <value>O caminho salvo do Hollow Knight é inválido. Por favor, selecione novamente um caminho válido.</value>
   </data>
   <data name="MWVM_Info" xml:space="preserve">
     <value>Info</value>
   </data>
   <data name="MWVM_UnableToDetect_Message" xml:space="preserve">
-    <value>Unable to detect your Hollow Knight installation. Please select it.</value>
+    <value>Não foi possível detectar a sua instalação do Hollow Knight. Por favor, selecione-a.</value>
   </data>
   <data name="MWVM_DetectedPath_Title" xml:space="preserve">
-    <value>Detected path!</value>
+    <value>Caminho detectado!</value>
   </data>
   <data name="MWVM_DetectedPath_Message" xml:space="preserve">
-    <value>Detected Hollow Knight install at {path.Root}. Is this correct?</value>
+    <value>Detectada uma instalação do Hollow Knight em {path.Root}. Isto está correto?</value>
   </data>
   <data name="XAML_ChangPath" xml:space="preserve">
-    <value>更改游戏目录</value>
+    <value>Alterar Caminho</value>
   </data>
   <data name="XAML_Dependencies" xml:space="preserve">
-    <value>依赖Mods：</value>
+    <value>\nDependências:\n</value>
   </data>
   <data name="XAML_Donate" xml:space="preserve">
-    <value>捐赠</value>
+    <value>Doar</value>
   </data>
   <data name="XAML_ModsFilter_All" xml:space="preserve">
-    <value>所有Mods</value>
+    <value>Todos</value>
   </data>
   <data name="XAML_ModsFilter_Enabled" xml:space="preserve">
-    <value>已启用</value>
+    <value>Ativos</value>
   </data>
   <data name="XAML_ModsFilter_Installed" xml:space="preserve">
-    <value>已安装</value>
+    <value>Instalados</value>
   </data>
   <data name="XAML_ModsFilter_OutOfDate" xml:space="preserve">
-    <value>已过时</value>
+    <value>Desatualizados</value>
   </data>
   <data name="XAML_OpenMods" xml:space="preserve">
-    <value>打开Mods文件夹</value>
+    <value>Abrir Mods</value>
   </data>
   <data name="XAML_Repository" xml:space="preserve">
-    <value>代码仓库：</value>
+    <value>\nRepositório:\n</value>
   </data>
   <data name="XAML_SearchMark" xml:space="preserve">
-    <value>搜索Mod</value>
+    <value>Pesquisar Mod</value>
   </data>
   <data name="XAML_UpdateAPI" xml:space="preserve">
-    <value>更新API</value>
+    <value>Atualizar API</value>
   </data>
   <data name="XAML_Version" xml:space="preserve">
-    <value>版本：</value>
+    <value>\nVersão:\n</value>
   </data>
   <data name="PU_NoSelect" xml:space="preserve">
-    <value>No path was selected!</value>
+    <value>Nenhum caminho foi selecionado!</value>
   </data>
   <data name="PU_NoSelectMac" xml:space="preserve">
-    <value>No application was selected!</value>
+    <value>Nenhuma aplicação foi selecionada!</value>
   </data>
   <data name="PU_InvalidPathHeader" xml:space="preserve">
-    <value>Invalid Hollow Knight path!</value>
+    <value>Caminho do Hollow Knight inválido!</value>
   </data>
   <data name="PU_InvalidAppHeader" xml:space="preserve">
-    <value>Invalid Hollow Knight app!</value>
+    <value>Aplicativo do Hollow Knight inválido!</value>
   </data>
   <data name="PU_InvalidPath" xml:space="preserve">
-    <value>Select the folder containing hollow_knight_Data or Hollow Knight_Data.</value>
+    <value>Selecione a pasta que contém hollow_knight_Data ou Hollow Knight_Data.</value>
   </data>
   <data name="PU_InvalidApp" xml:space="preserve">
-    <value>Missing Managed folder or Assembly-CSharp!</value>
+    <value>A pasta Managed ou o Assembly-CSharp está ausente!</value>
   </data>
   <data name="PU_SelectPath" xml:space="preserve">
-    <value>Select your Hollow Knight folder.</value>
+    <value>Selecione a sua pasta do Hollow Knight.</value>
   </data>
   <data name="PU_InvalidPathTitle" xml:space="preserve">
-    <value>Path</value>
+    <value>Caminho</value>
   </data>
   <data name="PU_SelectApp" xml:space="preserve">
-    <value>Select your Hollow Knight app.</value>
+    <value>Selecione o seu app do Hollow Knight.</value>
   </data>
 </root>

--- a/Scarab/Resources.pt-BR.resx
+++ b/Scarab/Resources.pt-BR.resx
@@ -196,7 +196,7 @@
     <value>Caminho detectado!</value>
   </data>
   <data name="MWVM_DetectedPath_Message" xml:space="preserve">
-    <value>Detectada uma instalação do Hollow Knight em {path.Root}. Isto está correto?</value>
+    <value>Detectada uma instalação do Hollow Knight em {0}. Isto está correto?</value>
   </data>
   <data name="XAML_ChangPath" xml:space="preserve">
     <value>Alterar Caminho</value>

--- a/Scarab/Resources.resx
+++ b/Scarab/Resources.resx
@@ -168,6 +168,36 @@
   <data name="MWVM_Impl_Error_Fetch_ModLinks_Timeout" xml:space="preserve">
     <value>timed out</value>
   </data>
+  <data name="MWVM_OutOfDate_GetLatest" xml:space="preserve">
+    <value>Get the latest release</value>
+  </data>
+  <data name="MWVM_OutOfDate_ContinueAnyways" xml:space="preserve">
+    <value>Continue anyways.</value>
+  </data>
+  <data name="MWVM_OutOfDate_Title" xml:space="preserve">
+    <value>Out of date!</value>
+  </data>
+  <data name="MWVM_OutOfDate_Message" xml:space="preserve">
+    <value>This program is out of date! It may not function correctly.</value>
+  </data>
+  <data name="MWVM_Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="MWVM_InvalidSavedPath_Message" xml:space="preserve">
+    <value>The saved Hollow Knight path is invalid, please re-select a valid path.</value>
+  </data>
+  <data name="MWVM_Info" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="MWVM_UnableToDetect_Message" xml:space="preserve">
+    <value>Unable to detect your Hollow Knight installation. Please select it.</value>
+  </data>
+  <data name="MWVM_DetectedPath_Title" xml:space="preserve">
+    <value>Detected path!</value>
+  </data>
+  <data name="MWVM_DetectedPath_Message" xml:space="preserve">
+    <value>Detected Hollow Knight install at {path.Root}. Is this correct?</value>
+  </data>
   <data name="XAML_ChangPath" xml:space="preserve">
     <value>Change Path</value>
   </data>
@@ -204,4 +234,32 @@
   <data name="XAML_Version" xml:space="preserve">
     <value>\nVersion:\n</value>
   </data>
+  <data name="PU_NoSelect" xml:space="preserve">
+    <value>No path was selected!</value>
+  </data>
+  <data name="PU_NoSelectMac" xml:space="preserve">
+    <value>No application was selected!</value>
+  </data>
+  <data name="PU_InvalidPathHeader" xml:space="preserve">
+    <value>Invalid Hollow Knight path!</value>
+  </data>
+  <data name="PU_InvalidAppHeader" xml:space="preserve">
+    <value>Invalid Hollow Knight app!</value>
+  </data>
+  <data name="PU_InvalidPath" xml:space="preserve">
+    <value>Select the folder containing hollow_knight_Data or Hollow Knight_Data.</value>
+  </data>
+  <data name="PU_InvalidApp" xml:space="preserve">
+    <value>Missing Managed folder or Assembly-CSharp!</value>
+  </data>
+  <data name="PU_SelectPath" xml:space="preserve">
+    <value>Select your Hollow Knight folder.</value>
+  </data>
+  <data name="PU_InvalidPathTitle" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="PU_SelectApp" xml:space="preserve">
+    <value>Select your Hollow Knight app.</value>
+  </data>
+  
 </root>

--- a/Scarab/Resources.resx
+++ b/Scarab/Resources.resx
@@ -196,7 +196,7 @@
     <value>Detected path!</value>
   </data>
   <data name="MWVM_DetectedPath_Message" xml:space="preserve">
-    <value>Detected Hollow Knight install at {path.Root}. Is this correct?</value>
+    <value>Detected Hollow Knight install at {0}. Is this correct?</value>
   </data>
   <data name="XAML_ChangPath" xml:space="preserve">
     <value>Change Path</value>

--- a/Scarab/Resources.zh.resx
+++ b/Scarab/Resources.zh.resx
@@ -196,7 +196,7 @@
     <value>Detected path!</value>
   </data>
   <data name="MWVM_DetectedPath_Message" xml:space="preserve">
-    <value>Detected Hollow Knight install at {path.Root}. Is this correct?</value>
+    <value>Detected Hollow Knight install at {0}. Is this correct?</value>
   </data>
   <data name="XAML_ChangPath" xml:space="preserve">
     <value>更改游戏目录</value>

--- a/Scarab/Scarab.csproj
+++ b/Scarab/Scarab.csproj
@@ -58,6 +58,9 @@
     </ItemGroup>
     
     <ItemGroup>
+      <EmbeddedResource Update="Resources.pt-BR.resx">
+        <Generator></Generator>
+      </EmbeddedResource>
       <EmbeddedResource Update="Resources.zh.resx">
         <Generator></Generator>
       </EmbeddedResource>

--- a/Scarab/Util/PathUtil.cs
+++ b/Scarab/Util/PathUtil.cs
@@ -14,15 +14,6 @@ namespace Scarab.Util
 {
     public static class PathUtil
     {
-        private const string NO_SELECT = "No path was selected!";
-        private const string NO_SELECT_MAC = "No application was selected!";
-
-        private const string INVALID_PATH_HEADER = "Invalid Hollow Knight path!";
-        private const string INVALID_APP_HEADER = "Invalid Hollow Knight app!";
-        
-        private const string INVALID_PATH = "Select the folder containing hollow_knight_Data or Hollow Knight_Data.";
-        private const string INVALID_APP = "Missing Managed folder or Assembly-CSharp!";
-        
         // There isn't any [return: MaybeNullWhen(param is null)] so this overload will have to do
         // Not really a huge point but it's nice to have the nullable static analysis
         public static async Task<string?> SelectPathFailable() => await SelectPath(true);
@@ -39,7 +30,7 @@ namespace Scarab.Util
 
             var dialog = new OpenFolderDialog
             {
-                Title = "Select your Hollow Knight folder.",
+                Title = Resources.PU_SelectPath,
             };
 
             while (true)
@@ -47,12 +38,12 @@ namespace Scarab.Util
                 string? result = await dialog.ShowAsync(parent);
 
                 if (result is null)
-                    await MessageBoxManager.GetMessageBoxStandardWindow("Path", NO_SELECT).Show();
+                    await MessageBoxManager.GetMessageBoxStandardWindow(Resources.PU_InvalidPathTitle, Resources.PU_NoSelect).Show();
                 else if (ValidateWithSuffix(result) is not (var managed, var suffix))
                     await MessageBoxManager.GetMessageBoxStandardWindow(new MessageBoxStandardParams {
-                        ContentTitle = "Path",
-                        ContentHeader = INVALID_PATH_HEADER,
-                        ContentMessage = INVALID_PATH,
+                        ContentTitle = Resources.PU_InvalidPathTitle,
+                        ContentHeader = Resources.PU_InvalidPathHeader,
+                        ContentMessage = Resources.PU_InvalidPath,
                         MinHeight = 140
                     }).Show();
                 else
@@ -67,7 +58,7 @@ namespace Scarab.Util
         {
             var dialog = new OpenFileDialog
             {
-                Title = "Select your Hollow Knight app.",
+                Title = Resources.PU_SelectApp,
                 Directory = "/Applications",
                 AllowMultiple = false
             };
@@ -79,12 +70,12 @@ namespace Scarab.Util
                 string[]? result = await dialog.ShowAsync(parent);
 
                 if (result is null or { Length: 0 })
-                    await MessageBoxManager.GetMessageBoxStandardWindow("Path", NO_SELECT_MAC).Show();
+                    await MessageBoxManager.GetMessageBoxStandardWindow(Resources.PU_InvalidPathTitle, Resources.PU_NoSelectMac).Show();
                 else if (ValidateWithSuffix(result.First()) is not (var managed, var suffix))
                     await MessageBoxManager.GetMessageBoxStandardWindow(new MessageBoxStandardParams {
-                        ContentTitle = "Path",
-                        ContentHeader = INVALID_APP_HEADER,
-                        ContentMessage = INVALID_APP,
+                        ContentTitle = Resources.PU_InvalidPathTitle,
+                        ContentHeader = Resources.PU_InvalidAppHeader,
+                        ContentMessage = Resources.PU_InvalidApp,
                         MinHeight = 200
                     }).Show();
                 else

--- a/Scarab/ViewModels/MainWindowViewModel.cs
+++ b/Scarab/ViewModels/MainWindowViewModel.cs
@@ -195,19 +195,19 @@ namespace Scarab.ViewModels
                         new ButtonDefinition {
                             IsDefault = true,
                             IsCancel = true,
-                            Name = "Get the latest release"
+                            Name = Resources.MWVM_OutOfDate_GetLatest
                         },
                         new ButtonDefinition {
-                            Name = "Continue anyways."
+                            Name = Resources.MWVM_OutOfDate_ContinueAnyways
                         }
                     },
-                    ContentTitle = "Out of date!",
-                    ContentMessage = "This program is out of date! It may not function correctly.",
+                    ContentTitle = Resources.MWVM_OutOfDate_Title,
+                    ContentMessage = Resources.MWVM_OutOfDate_Message,
                     SizeToContent = SizeToContent.WidthAndHeight
                 }
             ).Show();
 
-            if (res == "Get the latest release")
+            if (res == Resources.MWVM_OutOfDate_GetLatest)
             {
                 Process.Start(new ProcessStartInfo("https://github.com/fifty-six/Scarab/releases/latest") { UseShellExecute = true });
                 
@@ -226,8 +226,8 @@ namespace Scarab.ViewModels
             await MessageBoxManager.GetMessageBoxStandardWindow
             (
                 new MessageBoxStandardParams {
-                    ContentHeader = "Warning",
-                    ContentMessage = "The saved Hollow Knight path is invalid, please re-select a valid path.",
+                    ContentHeader = Resources.MWVM_Warning,
+                    ContentMessage = Resources.MWVM_InvalidSavedPath_Message,
                     // The auto-resize for this lib is buggy, so 
                     // ensure that the message doesn't get cut off 
                     MinWidth = 550
@@ -245,8 +245,9 @@ namespace Scarab.ViewModels
                 (
                     new MessageBoxStandardParams
                     {
-                        ContentHeader = "Info",
-                        ContentMessage = "Unable to detect your Hollow Knight installation. Please select it."
+                        ContentHeader = Resources.MWVM_Info,
+                        ContentMessage = Resources.MWVM_UnableToDetect_Message,
+                        MinWidth = 550
                     }
                 );
 
@@ -261,8 +262,8 @@ namespace Scarab.ViewModels
             (
                 new MessageBoxStandardParams
                 {
-                    ContentHeader = "Detected path!",
-                    ContentMessage = $"Detected Hollow Knight install at {path.Root}. Is this correct?",
+                    ContentHeader = Resources.MWVM_DetectedPath_Title,
+                    ContentMessage = string.Format(Resources.MWVM_DetectedPath_Message, path.Root),
                     ButtonDefinitions = ButtonEnum.YesNo
                 }
             );

--- a/Scarab/resources.Designer.cs
+++ b/Scarab/resources.Designer.cs
@@ -320,5 +320,178 @@ namespace Scarab {
                 return ResourceManager.GetString("XAML_Version", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   No path was selected!
+        /// </summary>
+        internal static string PU_NoSelect {
+            get {
+                return ResourceManager.GetString("PU_NoSelect", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   No application was selected!
+        /// </summary>
+        internal static string PU_NoSelectMac {
+            get {
+                return ResourceManager.GetString("PU_NoSelectMac", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Invalid Hollow Knight path!
+        /// </summary>
+        internal static string PU_InvalidPathHeader {
+            get {
+                return ResourceManager.GetString("PU_InvalidPathHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Invalid Hollow Knight app!
+        /// </summary>
+        internal static string PU_InvalidAppHeader {
+            get {
+                return ResourceManager.GetString("PU_InvalidAppHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Select the folder containing hollow_knight_Data or Hollow Knight_Data.
+        /// </summary>
+        internal static string PU_InvalidPath {
+            get {
+                return ResourceManager.GetString("PU_InvalidPath", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Missing Managed folder or Assembly-CSharp!
+        /// </summary>
+        internal static string PU_InvalidApp {
+            get {
+                return ResourceManager.GetString("PU_InvalidApp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Select your Hollow Knight folder.
+        /// </summary>
+        internal static string PU_SelectPath {
+            get {
+                return ResourceManager.GetString("PU_SelectPath", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///  Path 
+        /// </summary>
+        internal static string PU_InvalidPathTitle {
+            get {
+                return ResourceManager.GetString("PU_InvalidPathTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Select your Hollow Knight app.
+        /// </summary>
+        internal static string PU_SelectApp {
+            get {
+                return ResourceManager.GetString("PU_SelectApp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Get the latest release
+        /// </summary>
+        internal static string MWVM_OutOfDate_GetLatest {
+            get {
+                return ResourceManager.GetString("MWVM_OutOfDate_GetLatest", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Continue anyways.
+        /// </summary>
+        internal static string MWVM_OutOfDate_ContinueAnyways {
+            get {
+                return ResourceManager.GetString("MWVM_OutOfDate_ContinueAnyways", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Out of date!
+        /// </summary>
+        internal static string MWVM_OutOfDate_Title {
+            get {
+                return ResourceManager.GetString("MWVM_OutOfDate_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   This program is out of date! It may not function correctly.
+        /// </summary>
+        internal static string MWVM_OutOfDate_Message {
+            get {
+                return ResourceManager.GetString("MWVM_OutOfDate_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Warning
+        /// </summary>
+        internal static string MWVM_Warning {
+            get {
+                return ResourceManager.GetString("MWVM_Warning", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   The saved Hollow Knight path is invalid, please re-select a valid path.
+        /// </summary>
+        internal static string MWVM_InvalidSavedPath_Message {
+            get {
+                return ResourceManager.GetString("MWVM_InvalidSavedPath_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Info
+        /// </summary>
+        internal static string MWVM_Info {
+            get {
+                return ResourceManager.GetString("MWVM_Info", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Unable to detect your Hollow Knight installation. Please select it.
+        /// </summary>
+        internal static string MWVM_UnableToDetect_Message {
+            get {
+                return ResourceManager.GetString("MWVM_UnableToDetect_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Detected path!
+        /// </summary>
+        internal static string MWVM_DetectedPath_Title {
+            get {
+                return ResourceManager.GetString("MWVM_DetectedPath_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Detected Hollow Knight install at {path.Root}. Is this correct?
+        /// </summary>
+        internal static string MWVM_DetectedPath_Message {
+            get {
+                return ResourceManager.GetString("MWVM_DetectedPath_Message", resourceCulture);
+            }
+        }
+        
+
     }
 }


### PR DESCRIPTION
+ Added pt-BR language
+ Configuring the remaining strings in PathUtils and MainWindowViewModel which were not configured for internationalization.
+ Added `MinWidth = 550` in one message box so the text doesn't get cut

There were some strings that were missing in the last commit so I mapped them. Pretty sure I've found all of them. Everything should be working fine.