### PR TITLE
prevent unhandled exceptions by not awaiting tasks concurrently

### DIFF
--- a/Scarab/Services/ModDatabase.cs
+++ b/Scarab/Services/ModDatabase.cs
@@ -62,10 +62,10 @@ namespace Scarab.Services
         
         public static async Task<(ModLinks, ApiLinks)> FetchContent(HttpClient hc)
         {
-            Task<ModLinks> ml = FetchModLinks(hc);
-            Task<ApiLinks> al = FetchApiLinks(hc);
+            ModLinks ml = await FetchModLinks(hc);
+            ApiLinks al = await FetchApiLinks(hc);
 
-            return (await ml, await al);
+            return (ml, al);
         }
         
         private static T FromString<T>(string xml)


### PR DESCRIPTION
by doing (await ml, await al), if al threw before ml was fully awaited, it would cause an unhandled exception (because different thread so the try catch in MainWindowViewModel wouldn't catch it). This would lead to scarab just showing blank screen with no error or anything. Although it's less efficient, its better to handle errors properly