### PR TITLE
Update a Strange ZH translation

### DIFF
--- a/Scarab/Resources.zh.resx
+++ b/Scarab/Resources.zh.resx
@@ -241,7 +241,7 @@
     <value>标签</value>
   </data>
   <data name="XAML_On" xml:space="preserve">
-    <value>活性</value>
+    <value>启用</value>
   </data>
   <data name="XAML_Off" xml:space="preserve">
     <value>禁用</value>


### PR DESCRIPTION
![image](https://github.com/fifty-six/Scarab/assets/35688135/db448691-ee4d-4235-b1ba-055dddd5df9c)

The word "on" has been translated into "活性" (usually refers to the concept of activity in chemistry), the correct translation should be "启用" (enabled/turn on).