### PR TITLE
Added another default location for linux

### DIFF
--- a/Scarab/Settings.cs
+++ b/Scarab/Settings.cs
@@ -37,8 +37,9 @@ namespace Scarab
 
         private static readonly ImmutableList<string> USER_SUFFIX_PATHS = new List<string>
         {
-            // Default location on linux
+            // Default locations on linux
             ".local/share/Steam/steamapps/common/Hollow Knight",
+            ".steam/steam/steamapps/common/Hollow Knight",
             // Flatpak
             ".var/app/ocm.valvesoftware.Steam/data/Steam/steamapps/common",
             // Symlinks to the Steam root on linux


### PR DESCRIPTION
Added another location for the software to look for the hollow knight installation. 
I believe this is where the installation is when steam is installed through apt.