### PR TITLE
Support Game Pass installs, fix custom paths with spaces

### DIFF
--- a/Scarab/Settings.cs
+++ b/Scarab/Settings.cs
@@ -31,7 +31,8 @@ namespace Scarab
             "Program Files/GOG Galaxy/Games/Hollow Knight",
             "Program Files (x86)/GOG Galaxy/Games/Hollow Knight",
             "Steam/steamapps/common/Hollow Knight",
-            "GOG Galaxy/Games/Hollow Knight"
+            "GOG Galaxy/Games/Hollow Knight",
+            "XboxGames/Hollow Knight/Content"
         }
         .SelectMany(path => DriveInfo.GetDrives().Select(d => Path.Combine(d.Name, path))).ToImmutableList();
 

--- a/Scarab/Util/PathUtil.cs
+++ b/Scarab/Util/PathUtil.cs
@@ -40,7 +40,7 @@ namespace Scarab.Util
 
                 if (result is null)
                     await MessageBoxManager.GetMessageBoxStandardWindow(Resources.PU_InvalidPathTitle, Resources.PU_NoSelect).Show();
-                else if (ValidateWithSuffix(result.Path.AbsolutePath) is not var (managed, suffix))
+                else if (ValidateWithSuffix(result.Path.LocalPath) is not var (managed, suffix))
                     await MessageBoxManager.GetMessageBoxStandardWindow(new MessageBoxStandardParams {
                         ContentTitle = Resources.PU_InvalidPathTitle,
                         ContentHeader = Resources.PU_InvalidPathHeader,


### PR DESCRIPTION
Game Pass installs support mods now.

Also, `Path.AbsolutePath` converts spaces to `%20`, which later break when the directory exists. Changed to `LocaPath` since it is used to find a local path on the current machine.

Tested by running installing the Archipelago mod on a Game Pass install.