### PR TITLE
fix(NuGet.Config): be more precise about nuget package sources

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Avalonia Nightly" value="https://pkgs.dev.azure.com/AvaloniaUI/AvaloniaUI/_packaging/avalonia-all/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This change is inspired by this [nixpkgs PR](https://github.com/NixOS/nixpkgs/pull/336824) whose changes now require the nixpkgs package, at least for now, to explicitly add the default nuget source.

While it's not wrong to not have it here, nor is it needed explicitly, it might be a good idea to explicitly add the default source here anyway.