### PR TITLE
build: bump dotnet from 6 to 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore -r win-x64
     - name: Build
@@ -24,7 +24,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Scarab-Windows
-        path: Scarab/bin/Release/net6.0/win-x64/publish/
+        path: Scarab/bin/Release/net8.0/win-x64/publish/
 
   build-linux:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore -r linux-x64
     - name: Build
@@ -45,7 +45,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Scarab-Linux
-        path: Scarab/bin/Release/net6.0/linux-x64/publish/
+        path: Scarab/bin/Release/net8.0/linux-x64/publish/
 
   build-macos:
     runs-on: macos-latest
@@ -56,7 +56,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore -r osx-x64
     - name: Build
@@ -65,7 +65,7 @@ jobs:
         dotnet publish --no-restore -r osx-x64 -p:PublishSingleFile=true -p:Configuration=Release --self-contained true
         cd ..
         mkdir out
-        python3 make_app.py Scarab.app Scarab/bin/Release/net6.0/osx-x64/publish
+        python3 make_app.py Scarab.app Scarab/bin/Release/net8.0/osx-x64/publish
     - name: Upload Binary
       uses: actions/upload-artifact@v4
       with:

--- a/Scarab.Tests/Scarab.Tests.csproj
+++ b/Scarab.Tests/Scarab.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Scarab/Scarab.csproj
+++ b/Scarab/Scarab.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <!-- Windowed exe, avoids Console showing for users. -->
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <Version>2.5.0.0</Version>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "8.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
.NET 6 recently went end of support, see more at: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle